### PR TITLE
chwVertexBind: Updated makePaintable mel command to match current node name.

### DIFF
--- a/src/chwVertexBind.cpp
+++ b/src/chwVertexBind.cpp
@@ -95,7 +95,7 @@ MStatus chwVertexBind::initialize()
 	attributeAffects(chwVertexBind::aInitialize, 	chwVertexBind::outputGeom);
 	attributeAffects(chwVertexBind::aVertexMap,		chwVertexBind::outputGeom);
 
-	MGlobal::executeCommand( "makePaintable -attrType \"multiFloat\" -sm \"deformer\" \"vertSnap\" \"weights\";" );
+	MGlobal::executeCommand( "makePaintable -attrType \"multiFloat\" -sm \"deformer\" \"chwVertexBind\" \"weights\";" );
 
 	return MStatus::kSuccess;
 }


### PR DESCRIPTION
This updates the mel command to use the new name `chwVertexBind` rather than `vertSnap`.